### PR TITLE
Update variables.py

### DIFF
--- a/mysql_mimic/variables.py
+++ b/mysql_mimic/variables.py
@@ -37,6 +37,7 @@ SYSTEM_VARIABLES: dict[str, VariableSchema] = {
     "max_allowed_packet": (int, 67108864, True),
     "max_execution_time": (int, 0, True),
     "net_write_timeout": (int, 28800, True),
+    "net_buffer_length": (int, 16384, True),
     "performance_schema": (bool, False, False),
     "sql_auto_is_null": (bool, False, True),
     "sql_mode": (str, "ANSI", True),


### PR DESCRIPTION
Add a system variable `net_buffer_length`.

Required by Google App Script JDBC API that stats with the query
```sql
SELECT @@session.auto_increment_increment AS auto_increment_increment,
       @@character_set_client             AS character_set_client,
       @@character_set_connection         AS character_set_connection,
       @@character_set_results            AS character_set_results,
       @@character_set_server             AS character_set_server,
       @@collation_server                 AS collation_server,
       @@collation_connection             AS collation_connection,
       @@init_connect                     AS init_connect,
       @@interactive_timeout              AS interactive_timeout,
       @@license                          AS license,
       @@lower_case_table_names           AS lower_case_table_names,
       @@max_allowed_packet               AS max_allowed_packet,
       @@net_buffer_length                AS net_buffer_length,
       @@net_write_timeout                AS net_write_timeout,
       @@sql_mode                         AS sql_mode,
       @@system_time_zone                 AS system_time_zone,
       @@time_zone                        AS time_zone,
       @@transaction_isolation            AS transaction_isolation,
       @@wait_timeout                     AS wait_timeout
```