### PR TITLE
Support DESCRIBE command

### DIFF
--- a/mysql_mimic/session.py
+++ b/mysql_mimic/session.py
@@ -283,7 +283,11 @@ class Session(BaseSession):
         if isinstance(expression, exp.Describe):
             name = expression.this.name
             show = self.dialect().parse(f"SHOW COLUMNS FROM {name}")[0]
-            return await self._show_interceptor(show) if isinstance(show, exp.Expression) else None
+            return (
+                await self._show_interceptor(show)
+                if isinstance(show, exp.Expression)
+                else None
+            )
         return None
 
     async def _rollback_interceptor(self, expression: exp.Expression) -> AllowedResult:

--- a/mysql_mimic/session.py
+++ b/mysql_mimic/session.py
@@ -120,6 +120,7 @@ class Session(BaseSession):
             self._static_query_interceptor,
             self._use_interceptor,
             self._show_interceptor,
+            self._describe_interceptor,
             self._rollback_interceptor,
             self._info_schema_interceptor,
         ]
@@ -275,6 +276,13 @@ class Session(BaseSession):
                 return self._show_errors(expression)
             select = show_statement_to_info_schema_query(expression)
             return await self._query_info_schema(select)
+        return None
+
+    async def _describe_interceptor(self, expression: exp.Expression) -> AllowedResult:
+        """Intercept DESCRIBE statements"""
+        if isinstance(expression, exp.Describe):
+            name = expression.this.name
+            return await self.handle_query(f"SHOW COLUMNS FROM {name}", {})
         return None
 
     async def _rollback_interceptor(self, expression: exp.Expression) -> AllowedResult:

--- a/mysql_mimic/session.py
+++ b/mysql_mimic/session.py
@@ -282,7 +282,8 @@ class Session(BaseSession):
         """Intercept DESCRIBE statements"""
         if isinstance(expression, exp.Describe):
             name = expression.this.name
-            return await self.handle_query(f"SHOW COLUMNS FROM {name}", {})
+            show = self.dialect().parse(f"SHOW COLUMNS FROM {name}")[0]
+            return await self._show_interceptor(show)
         return None
 
     async def _rollback_interceptor(self, expression: exp.Expression) -> AllowedResult:

--- a/mysql_mimic/session.py
+++ b/mysql_mimic/session.py
@@ -283,7 +283,7 @@ class Session(BaseSession):
         if isinstance(expression, exp.Describe):
             name = expression.this.name
             show = self.dialect().parse(f"SHOW COLUMNS FROM {name}")[0]
-            return await self._show_interceptor(show)
+            return await self._show_interceptor(show) if isinstance(show, exp.Expression) else None
         return None
 
     async def _rollback_interceptor(self, expression: exp.Expression) -> AllowedResult:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -686,6 +686,27 @@ async def test_query_attributes(
             ],
         ),
         (
+            "describe x",
+            [
+                {
+                    "Default": None,
+                    "Extra": None,
+                    "Field": "a",
+                    "Key": None,
+                    "Null": "YES",
+                    "Type": "TEXT",
+                },
+                {
+                    "Default": None,
+                    "Extra": None,
+                    "Field": "b",
+                    "Key": None,
+                    "Null": "YES",
+                    "Type": "TEXT",
+                },
+            ],
+        ),
+        (
             "show tables from information_schema like 'k%'",
             [
                 {"Table_name": "key_column_usage"},


### PR DESCRIPTION
Since `DESCRIBE` is a shortcut of the `SHOW COLUMNS` this implementation is using the same flow to show columns on table which is on describe command.