### PR TITLE
Improve SHOW commands MySQL compatibility 

### DIFF
--- a/mysql_mimic/schema.py
+++ b/mysql_mimic/schema.py
@@ -180,7 +180,8 @@ def show_statement_to_info_schema_query(
         table = show.text("target")
         if not table:
             raise MysqlError(
-                "You have an error in your SQL syntax. Table name is missing.", code=ErrorCode.PARSE_ERROR
+                "You have an error in your SQL syntax. Table name is missing.",
+                code=ErrorCode.PARSE_ERROR,
             )
         select = (
             exp.select(*outputs)
@@ -201,9 +202,7 @@ def show_statement_to_info_schema_query(
         select = exp.select(*outputs).from_("information_schema.tables")
         db = show.text("db") or database
         if not db:
-            raise MysqlError(
-                "No database selected.", code=ErrorCode.NO_DB_ERROR
-            )
+            raise MysqlError("No database selected.", code=ErrorCode.NO_DB_ERROR)
         select = select.where(f"table_schema = '{db}'")
         like = show.text("like")
         if like:
@@ -236,7 +235,8 @@ def show_statement_to_info_schema_query(
         table = show.text("target")
         if not table:
             raise MysqlError(
-                "You have an error in your SQL syntax. Table name is missing.", code=ErrorCode.PARSE_ERROR
+                "You have an error in your SQL syntax. Table name is missing.",
+                code=ErrorCode.PARSE_ERROR,
             )
         select = (
             exp.select(*outputs)

--- a/mysql_mimic/schema.py
+++ b/mysql_mimic/schema.py
@@ -178,6 +178,10 @@ def show_statement_to_info_schema_query(
                 ]
             )
         table = show.text("target")
+        if not table:
+            raise MysqlError(
+                f"You have an error in your SQL syntax. Table name is missing.", code=ErrorCode.PARSE_ERROR
+            )
         select = (
             exp.select(*outputs)
             .from_("information_schema.columns")
@@ -227,6 +231,10 @@ def show_statement_to_info_schema_query(
             '"expression" AS Expression',
         ]
         table = show.text("target")
+        if not table:
+            raise MysqlError(
+                f"You have an error in your SQL syntax. Table name is missing.", code=ErrorCode.PARSE_ERROR
+            )
         select = (
             exp.select(*outputs)
             .from_("information_schema.statistics")

--- a/mysql_mimic/schema.py
+++ b/mysql_mimic/schema.py
@@ -180,7 +180,7 @@ def show_statement_to_info_schema_query(
         table = show.text("target")
         if not table:
             raise MysqlError(
-                f"You have an error in your SQL syntax. Table name is missing.", code=ErrorCode.PARSE_ERROR
+                "You have an error in your SQL syntax. Table name is missing.", code=ErrorCode.PARSE_ERROR
             )
         select = (
             exp.select(*outputs)
@@ -202,7 +202,7 @@ def show_statement_to_info_schema_query(
         db = show.text("db") or database
         if not db:
             raise MysqlError(
-                f"No database selected.", code=ErrorCode.NO_DB_ERROR
+                "No database selected.", code=ErrorCode.NO_DB_ERROR
             )
         select = select.where(f"table_schema = '{db}'")
         like = show.text("like")
@@ -236,7 +236,7 @@ def show_statement_to_info_schema_query(
         table = show.text("target")
         if not table:
             raise MysqlError(
-                f"You have an error in your SQL syntax. Table name is missing.", code=ErrorCode.PARSE_ERROR
+                "You have an error in your SQL syntax. Table name is missing.", code=ErrorCode.PARSE_ERROR
             )
         select = (
             exp.select(*outputs)

--- a/mysql_mimic/schema.py
+++ b/mysql_mimic/schema.py
@@ -200,8 +200,11 @@ def show_statement_to_info_schema_query(
 
         select = exp.select(*outputs).from_("information_schema.tables")
         db = show.text("db") or database
-        if db:
-            select = select.where(f"table_schema = '{db}'")
+        if not db:
+            raise MysqlError(
+                f"No database selected.", code=ErrorCode.NO_DB_ERROR
+            )
+        select = select.where(f"table_schema = '{db}'")
         like = show.text("like")
         if like:
             select = select.where(f"table_name LIKE '{like}'")


### PR DESCRIPTION
### Problems
* `SHOW TABLES` returns all the tables. It's fine until there is same table name on different databases
* `SHOW COLUMNS` and `SHOW INDEX` return empty answer instead of parse error

### Changes
* `SHOW TABLES` returns no database selected error 
* `SHOW COLUMNS` and `SHOW INDEX` return parse error and warns about missing table name