### PR TITLE
fix: support concrete info functions

### DIFF
--- a/mysql_mimic/session.py
+++ b/mysql_mimic/session.py
@@ -302,9 +302,15 @@ class Session(BaseSession):
         def _transform(node: exp.Expression) -> exp.Expression:
             new_node = None
 
-            if isinstance(node, exp.Anonymous) and node.name.upper() in self._functions:
-                value = self._functions[node.name.upper()]()
-                new_node = value_to_expression(value)
+            if isinstance(node, exp.Func):
+                if isinstance(node, exp.Anonymous):
+                    func_name = node.name.upper()
+                else:
+                    func_name = node.sql_name()
+                func = self._functions.get(func_name)
+                if func:
+                    value = func()
+                    new_node = value_to_expression(value)
             elif isinstance(node, exp.Column) and node.sql() == "CURRENT_USER":
                 value = self._functions["CURRENT_USER"]()
                 new_node = value_to_expression(value)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -253,7 +253,7 @@ async def test_replace_function(
         assert result[0]["CONNECTION_ID()"] is not None
 
         result = await query(conn, "SELECT CURRENT_USER")
-        assert result[0]["CURRENT_USER"] == "levon_helm"
+        assert result[0]["CURRENT_USER()"] == "levon_helm"
 
         result = await query(conn, "SELECT USER()")
         assert result[0]["USER()"] == "levon_helm"


### PR DESCRIPTION
CURRENT_USER() is now an actual function in sqlglot

@ginter 