### PR TITLE
remove kerberos mutual auth

### DIFF
--- a/integration/mysql-connector-j/src/test/java/com/mysql_mimic/integration/IntegrationTest.java
+++ b/integration/mysql-connector-j/src/test/java/com/mysql_mimic/integration/IntegrationTest.java
@@ -53,19 +53,11 @@ public class IntegrationTest
         Connection conn = DriverManager.getConnection(url);
 
         Statement stmt = conn.createStatement();
-        ResultSet rs = stmt.executeQuery("SELECT a FROM x ORDER BY a");
+        ResultSet rs = stmt.executeQuery("SELECT CURRENT_USER AS CURRENT_USER");
 
-        List<Integer> result = new ArrayList<>();
-        while (rs.next()) {
-            result.add(rs.getInt("a"));
-        }
+        rs.next();
 
-        List<Integer> expected = new ArrayList<>();
-        expected.add(1);
-        expected.add(2);
-        expected.add(3);
-
-        assertEquals(expected, result);
+        assertEquals("krb5_user", rs.getString("CURRENT_USER"));
     }
 
     @Test(expected = SQLException.class)

--- a/mysql_mimic/auth.py
+++ b/mysql_mimic/auth.py
@@ -213,7 +213,7 @@ class KerberosAuthPlugin(AuthPlugin):
         except GSSError as e:
             yield Forbidden(str(e))
 
-        username = str(server_ctx.initiator_name).split("@")[0]
+        username = str(server_ctx.initiator_name).split("@", 1)[0]
         if auth_info.username and auth_info.username != username:
             yield Forbidden("Given username different than kerberos client")
         yield Success(username)

--- a/mysql_mimic/auth.py
+++ b/mysql_mimic/auth.py
@@ -190,6 +190,7 @@ class KerberosAuthPlugin(AuthPlugin):
 
     async def auth(self, auth_info: Optional[AuthInfo] = None) -> AuthState:
         import gssapi
+        from gssapi.exceptions import GSSError
 
         # Fast authentication not supported
         if not auth_info:
@@ -207,19 +208,15 @@ class KerberosAuthPlugin(AuthPlugin):
         )
         server_ctx = gssapi.SecurityContext(usage="accept", creds=server_creds)
 
-        client_name = gssapi.Name(f"{auth_info.username}@{self.realm}").canonicalize(
-            gssapi.MechType.kerberos
-        )
-        client_token = auth_info.data
+        try:
+            server_ctx.step(auth_info.data)
+        except GSSError as e:
+            yield Forbidden(str(e))
 
-        server_token = server_ctx.step(client_token)
-
-        if server_ctx.initiator_name == client_name:
-            if gssapi.RequirementFlag.mutual_authentication in server_ctx.actual_flags:
-                auth_info = yield server_token
-            yield Success(auth_info.username)
-        else:
-            yield Forbidden()
+        username = str(server_ctx.initiator_name).split("@")[0]
+        if auth_info.username and auth_info.username != username:
+            yield Forbidden("Given username different than kerberos client")
+        yield Success(username)
 
 
 class NoLoginAuthPlugin(AuthPlugin):


### PR DESCRIPTION
The current implementation doesn't work and breaks mysql-connector-python.
Its hard to know how to fix this, because we don't have access to the reference implementation. So just removing for now.
