### PR TITLE
fix: readexactly, not read

### DIFF
--- a/mysql_mimic/stream.py
+++ b/mysql_mimic/stream.py
@@ -39,7 +39,7 @@ class MysqlStream:
             if payload_length == 0:
                 return data
 
-            data += await self.reader.read(payload_length)
+            data += await self.reader.readexactly(payload_length)
 
             if payload_length < 0xFFFFFF:
                 return data

--- a/mysql_mimic/stream.py
+++ b/mysql_mimic/stream.py
@@ -39,7 +39,7 @@ class MysqlStream:
             if payload_length == 0:
                 return data
 
-            data += await self.reader.readexactly(payload_length)
+            data += await self.reader.read(payload_length)
 
             if payload_length < 0xFFFFFF:
                 return data

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -286,7 +286,7 @@ async def test_query_attributes(
     await query(
         sql=sql,
         conn=mysql_connector_conn,
-        query_attributes=query_attrs,
+        query_attributes=query_attrs,  # type: ignore
         cursor_class=cursor_class,
     )
     assert session.last_query_attrs == query_attrs

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -274,22 +274,25 @@ async def test_query_attributes(
 ) -> None:
     session.echo = True
 
-    for i, q in enumerate(
-        [
-            partial(query, conn=mysql_connector_conn),
-            partial(query, conn=mysql_connector_conn, cursor_class=PreparedDictCursor),
-        ]
-    ):
-        session.last_query_attrs = None
-        sql = "SELECT 1 FROM x"
-        query_attrs = {
-            "idx": i,
-            "str": "foo",
-            "int": 1,
-            "float": 1.1,
-        }
-        await q(sql=sql, query_attributes=query_attrs)
-        assert session.last_query_attrs == query_attrs
+    sql = "SELECT 1 FROM x"
+    query_attrs = {
+        "id": "foo",
+        "str": "foo",
+        "int": 1,
+        "float": 1.1,
+    }
+    await query(sql=sql, conn=mysql_connector_conn, query_attributes=query_attrs)
+    assert session.last_query_attrs == query_attrs
+
+    session.last_query_attrs = None
+    query_attrs = {**query_attrs, "id": "bar"}
+    await query(
+        sql=sql,
+        conn=mysql_connector_conn,
+        query_attributes=query_attrs,
+        cursor_class=PreparedDictCursor,
+    )
+    assert session.last_query_attrs == query_attrs
 
 
 # pylint: disable=trailing-whitespace

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,7 +1,6 @@
 import io
 from contextlib import closing
 from datetime import date, datetime, timedelta
-from functools import partial
 from typing import Any, Callable, Awaitable, Sequence, Dict, List, Tuple, Type
 
 import pytest

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -16,6 +16,8 @@ class MockReader:
 
         return self.data[start:end]
 
+    readexactly = read
+
 
 class MockWriter:
     def __init__(self) -> None:


### PR DESCRIPTION
We think we've found a bug when clients send large payloads.

The underlying TCP protocol will split packets into segments. `read` doesn't wait for all n bytes - it reads _up to_ n bytes. So if all the segments haven't arrived yet, we wont read the entire packet.