### PR TITLE
feat: allow connect_attrs to affect identity

### DIFF
--- a/mysql_mimic/auth.py
+++ b/mysql_mimic/auth.py
@@ -245,7 +245,7 @@ class IdentityProvider:
     def get_plugins(self) -> Sequence[AuthPlugin]:
         return [NativePasswordAuthPlugin(), NoLoginAuthPlugin()]
 
-    async def get_user(self, username: str) -> Optional[User]:
+    async def get_user(self, username: str, connect_attrs: Dict[str, str]) -> Optional[User]:
         return None
 
     def get_default_plugin(self) -> AuthPlugin:
@@ -263,5 +263,5 @@ class SimpleIdentityProvider(IdentityProvider):
     Simple identity provider implementation that naively accepts whatever username a client provides.
     """
 
-    async def get_user(self, username: str) -> Optional[User]:
+    async def get_user(self, username: str, connect_attrs: Dict[str, str]) -> Optional[User]:
         return User(name=username, auth_plugin=NativePasswordAuthPlugin.name)

--- a/mysql_mimic/connection.py
+++ b/mysql_mimic/connection.py
@@ -205,7 +205,7 @@ class Connection:
         auth_state: Optional[AuthState] = None,
         server_plugin: Optional[AuthPlugin] = None,
     ) -> None:
-        user = await self.identity_provider.get_user(username)
+        user = await self.identity_provider.get_user(username, connect_attrs)
 
         if not user:
             await self.stream.write(


### PR DESCRIPTION
This is a breaking change I assume, due to breaking any custom identify providers in the wild.