### PR TITLE
fix: throw an error when session factory fails

### DIFF
--- a/mysql_mimic/packets.py
+++ b/mysql_mimic/packets.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Dict, Any, Sequence, Callable, Tuple, List, Union
 
 from mysql_mimic.charset import Collation, CharacterSet
+from mysql_mimic.constants import DEFAULT_SERVER_CAPABILITIES
 from mysql_mimic.errors import ErrorCode, get_sqlstate, MysqlError
 from mysql_mimic.prepared import PreparedStatement, REGEX_PARAM
 from mysql_mimic.results import NullBitmap, ResultColumn
@@ -153,9 +154,9 @@ def make_eof(
 
 
 def make_error(
-    capabilities: Capabilities,
-    server_charset: CharacterSet,
-    msg: Any,
+    capabilities: Capabilities = DEFAULT_SERVER_CAPABILITIES,
+    server_charset: CharacterSet = CharacterSet.utf8mb4,
+    msg: Any = "",
     code: ErrorCode = ErrorCode.UNKNOWN_ERROR,
 ) -> bytes:
     parts = [uint_1(0xFF), uint_2(code)]

--- a/mysql_mimic/server.py
+++ b/mysql_mimic/server.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 from ssl import SSLContext
 from socket import socket
 from typing import Callable, Any, Optional, Sequence, Awaitable
 
+from mysql_mimic import packets
 from mysql_mimic.auth import IdentityProvider, SimpleIdentityProvider
+from mysql_mimic.charset import CharacterSet
 from mysql_mimic.connection import Connection
 from mysql_mimic.control import Control, LocalControl, TooManyConnections
 from mysql_mimic.errors import ErrorCode
@@ -14,6 +17,9 @@ from mysql_mimic.session import Session, BaseSession
 from mysql_mimic.constants import DEFAULT_SERVER_CAPABILITIES
 from mysql_mimic.stream import MysqlStream
 from mysql_mimic.types import Capabilities
+
+
+logger = logging.getLogger(__name__)
 
 
 class MaxConnectionsExceeded(Exception):
@@ -58,22 +64,32 @@ class MysqlServer:
     ) -> None:
         stream = MysqlStream(reader, writer)
 
-        if inspect.iscoroutinefunction(self.session_factory):
-            session = await self.session_factory()
-        else:
-            session = self.session_factory()
+        try:
+            if inspect.iscoroutinefunction(self.session_factory):
+                session = await self.session_factory()
+            else:
+                session = self.session_factory()
 
-        connection = Connection(
-            stream=stream,
-            session=session,
-            control=self.control,
-            server_capabilities=self.capabilities,
-            identity_provider=self.identity_provider,
-            ssl=self.ssl,
-        )
+            connection = Connection(
+                stream=stream,
+                session=session,
+                control=self.control,
+                server_capabilities=self.capabilities,
+                identity_provider=self.identity_provider,
+                ssl=self.ssl,
+            )
+
+        except Exception:
+            logger.exception("Failed to create connection")
+            await stream.write(
+                # Return an error so clients don't freeze
+                packets.make_error(capabilities=self.capabilities)
+            )
+            return
 
         try:
             connection_id = await self.control.add(connection)
+            connection.connection_id = connection_id
         except TooManyConnections:
             await stream.write(
                 connection.error(
@@ -82,7 +98,13 @@ class MysqlServer:
                 )
             )
             return
-        connection.connection_id = connection_id
+        except Exception:
+            logger.exception("Failed to register connection")
+            await stream.write(
+                connection.error(msg="Failed to register connection")
+            )
+            return
+
         try:
             return await connection.start()
         finally:

--- a/mysql_mimic/server.py
+++ b/mysql_mimic/server.py
@@ -9,7 +9,6 @@ from typing import Callable, Any, Optional, Sequence, Awaitable
 
 from mysql_mimic import packets
 from mysql_mimic.auth import IdentityProvider, SimpleIdentityProvider
-from mysql_mimic.charset import CharacterSet
 from mysql_mimic.connection import Connection
 from mysql_mimic.control import Control, LocalControl, TooManyConnections
 from mysql_mimic.errors import ErrorCode
@@ -79,7 +78,7 @@ class MysqlServer:
                 ssl=self.ssl,
             )
 
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             logger.exception("Failed to create connection")
             await stream.write(
                 # Return an error so clients don't freeze
@@ -98,11 +97,9 @@ class MysqlServer:
                 )
             )
             return
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             logger.exception("Failed to register connection")
-            await stream.write(
-                connection.error(msg="Failed to register connection")
-            )
+            await stream.write(connection.error(msg="Failed to register connection"))
             return
 
         try:


### PR DESCRIPTION
Failures in the session factory were being silently ignored, and the client just hangs.