### PR TITLE
fix: handle DESCRIBE SELECT

### DIFF
--- a/mysql_mimic/session.py
+++ b/mysql_mimic/session.py
@@ -393,6 +393,9 @@ class Session(BaseSession):
     async def _describe_middleware(self, q: Query) -> AllowedResult:
         """Intercept DESCRIBE statements"""
         if isinstance(q.expression, exp.Describe):
+            if isinstance(q.expression.this, exp.Select):
+                # Mysql parse treats EXPLAIN SELECT as a DESCRIBE SELECT statement
+                return await q.next()
             name = q.expression.this.name
             show = self.dialect().parse(f"SHOW COLUMNS FROM {name}")[0]
             return await self._show(show) if isinstance(show, exp.Show) else None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,12 +78,6 @@ class MockSession(Session):
             await self.pause.wait()
             self.waiting.clear()
 
-        if isinstance(expression, exp.Describe):
-            assert isinstance(expression.this, exp.Select)
-            sql = expression.this.sql()
-            return [(sql,)], ["sql"]
-
-        assert isinstance(expression, exp.Select)
         self.last_query_attrs = attrs
         if self.echo:
             return [(sql,)], ["sql"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,12 @@ class MockSession(Session):
             self.waiting.set()
             await self.pause.wait()
             self.waiting.clear()
+
+        if isinstance(expression, exp.Describe):
+            assert isinstance(expression.this, exp.Select)
+            sql = expression.this.sql()
+            return [(sql,)], ["sql"]
+
         assert isinstance(expression, exp.Select)
         self.last_query_attrs = attrs
         if self.echo:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -292,6 +292,7 @@ async def test_query_attributes(
     )
     assert session.last_query_attrs == query_attrs
 
+
 @pytest.mark.asyncio
 async def test_describe_select(
     session: MockSession,
@@ -302,8 +303,7 @@ async def test_describe_select(
     sql = "DESCRIBE SELECT b from a"
     with freeze_time("2023-01-01"):
         result = await query_fixture(sql)
-        assert [{'sql': 'DESCRIBE SELECT b from a'}] == list(result)
-
+        assert [{"sql": "DESCRIBE SELECT b from a"}] == list(result)
 
 
 # pylint: disable=trailing-whitespace

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -731,6 +731,15 @@ async def test_query_attributes(
             ],
         ),
         (
+            "describe SELECT b FROM a",
+            [
+                {
+                    "sql": "SELECT b FROM a",
+                },
+
+            ],
+        ),
+        (
             "show tables from information_schema like 'k%'",
             [
                 {"Table_name": "key_column_usage"},

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -736,7 +736,6 @@ async def test_query_attributes(
                 {
                     "sql": "SELECT b FROM a",
                 },
-
             ],
         ),
         (

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -73,10 +73,10 @@ async def query_fixture(
     raise RuntimeError("Unexpected fixture param")
 
 
-# # Uncomment to make tests only use mysql-connector, which can help during debugging
+# Uncomment to make tests only use mysql-connector, which can help during debugging
 # @pytest_asyncio.fixture
 # async def query_fixture(
-#     mysql_connector_conn: MySQLConnection,
+#     mysql_connector_conn: MySQLConnectionAbstract,
 # ) -> QueryFixture:
 #     async def q1(sql: str) -> Sequence[Dict[str, Any]]:
 #         return await query(mysql_connector_conn, sql)
@@ -291,6 +291,19 @@ async def test_query_attributes(
         cursor_class=cursor_class,
     )
     assert session.last_query_attrs == query_attrs
+
+@pytest.mark.asyncio
+async def test_describe_select(
+    session: MockSession,
+    server: MysqlServer,
+    query_fixture: QueryFixture,
+) -> None:
+    session.echo = True
+    sql = "DESCRIBE SELECT b from a"
+    with freeze_time("2023-01-01"):
+        result = await query_fixture(sql)
+        assert [{'sql': 'DESCRIBE SELECT b from a'}] == list(result)
+
 
 
 # pylint: disable=trailing-whitespace
@@ -727,14 +740,6 @@ async def test_query_attributes(
                     "Key": None,
                     "Null": "YES",
                     "Type": "TEXT",
-                },
-            ],
-        ),
-        (
-            "describe SELECT b FROM a",
-            [
-                {
-                    "sql": "SELECT b FROM a",
                 },
             ],
         ),


### PR DESCRIPTION
Based on the below sentences from the mysql [doc](https://dev.mysql.com/doc/refman/8.4/en/explain.html)
"The [DESCRIBE](https://dev.mysql.com/doc/refman/8.4/en/describe.html) and [EXPLAIN](https://dev.mysql.com/doc/refman/8.4/en/explain.html) statements are synonyms."
["but the MySQL parser treats them as completely synonymous."](https://dev.mysql.com/doc/refman/8.4/en/explain.html)

"EXPLAIN SELECT * FROM table" is equal to "DESCRIBE SELECT * FROM table" so we should not rewrite all the DESCRIBE statement to SHOW.

@barakalon 