### PR TITLE
Fix mypyc build failure: accept bytearray in CharacterSet.decode()

### DIFF
--- a/mysql_mimic/charset.py
+++ b/mysql_mimic/charset.py
@@ -55,7 +55,7 @@ class CharacterSet(IntEnum):
     def default_collation(self) -> Collation:
         return DEFAULT_COLLATIONS[self]
 
-    def decode(self, b: bytes) -> str:
+    def decode(self, b: bytes | bytearray) -> str:
         return b.decode(self.codec)
 
     def encode(self, s: str) -> bytes:

--- a/tests/test_charset.py
+++ b/tests/test_charset.py
@@ -1,0 +1,17 @@
+from mysql_mimic.charset import CharacterSet
+
+
+def test_decode_bytes():
+    cs = CharacterSet.utf8mb4
+    assert cs.decode(b"hello") == "hello"
+
+
+def test_decode_bytearray():
+    """Regression test for https://github.com/barakalon/mysql-mimic/issues/72
+
+    CharacterSet.decode() must accept bytearray, not just bytes,
+    because _read_params() in packets.py passes bytearray buffers.
+    This caused mypyc builds to fail with an arg-type error.
+    """
+    cs = CharacterSet.utf8mb4
+    assert cs.decode(bytearray(b"hello")) == "hello"


### PR DESCRIPTION
## Summary

- `CharacterSet.decode()` was typed to accept only `bytes`, but `_read_params()` in `packets.py` passes `bytearray` buffers from the `buffers` dict
- This works at runtime but fails mypyc's strict mypy check (`[arg-type]`), breaking source builds on platforms without pre-built wheels (e.g. Windows)
- Widens the type signature to `bytes | bytearray` and adds a regression test

Fixes #72

## Root cause

Regular `mypy` (used in CI via `make types`) doesn't flag this because it runs without `--strict`. However, mypyc internally uses strict checking during `build_wheel`, which rejects the `bytearray` → `bytes` argument.

## Test plan

- [x] `python -m mypy mysql_mimic/packets.py --strict` passes (previously failed with `arg-type`)
- [x] `python -m pytest tests/test_charset.py` passes — verifies `decode()` works with both `bytes` and `bytearray`
- [x] `python -m black` reports no formatting changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)