### PR TITLE
CI: add mypyc type check and surface build errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,10 @@ jobs:
       if: matrix.version.python == '3.12'
       run: |
         make types
+    - name: Type annotations (mypyc strict)
+      if: matrix.version.python == '3.12'
+      run: |
+        make types-mypyc
   mysql-connector-j:
     name: Integration (mysql-connector-j)
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,12 @@ run:
 types:
 	python -m mypy -p mysql_mimic -p tests
 
-types-mypyc:
-	python -c "exec(open('setup.py').read().split('import sys')[0]); from mypyc.build import mypycify; mypycify(MYPYC_MODULES)"
-
 test:
 	coverage run --source=mysql_mimic -m pytest
 	coverage report
 	coverage html
 
-check: format-check types types-mypyc test
+check: format-check types test
 
 build: clean
 	python setup.py sdist bdist_wheel

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,15 @@ run:
 types:
 	python -m mypy -p mysql_mimic -p tests
 
+types-mypyc:
+	python -c "exec(open('setup.py').read().split('import sys')[0]); from mypyc.build import mypycify; mypycify(MYPYC_MODULES)"
+
 test:
 	coverage run --source=mysql_mimic -m pytest
 	coverage report
 	coverage html
 
-check: format-check types test
+check: format-check types types-mypyc test
 
 build: clean
 	python setup.py sdist bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,12 @@ ext_modules = []
 if sys.version_info >= (3, 9) and not os.environ.get("NO_MYPYC"):
     try:
         from mypyc.build import mypycify
-
+    except ImportError:
+        pass
+    else:
         ext_modules = mypycify(
             MYPYC_MODULES, opt_level=os.environ.get("MYPYC_OPT_LEVEL", "3")
         )
-    except Exception:
-        pass
 
 setup(
     name="mysql-mimic",


### PR DESCRIPTION
## Summary

- Add `make types-mypyc` CI step that runs `mypycify()` on `MYPYC_MODULES` from `setup.py`, catching type errors that regular mypy misses but mypyc rejects during wheel builds (e.g. #72)
- Fix `setup.py` to only catch `ImportError` (mypyc not installed) instead of bare `except Exception` which silently swallows type-check failures

## Why

Regular `mypy` (without `--strict`) does not catch the type errors that mypyc enforces during `build_wheel`. This means CI can pass while source builds fail on platforms without pre-built wheels. The `types-mypyc` target reads the module list directly from `setup.py`, so newly added mypyc modules are automatically covered.

The `try/except Exception: pass` in `setup.py` also masked build failures — narrowing to `ImportError` ensures real errors surface.

## Test plan

- [x] Verified `make types-mypyc` catches the known #72 arg-type error (exits code 1)
- [x] Verified `setup.py` still skips mypyc gracefully when not installed (ImportError path)
- [x] `black --check` passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)