### PR TITLE
fix: resolve mypyc compilation errors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,10 @@ jobs:
             arch: arm64
             skip: ""
             name: macos-arm64
+          - os: windows-latest
+            arch: AMD64
+            skip: ""
+            name: windows-x86_64
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         NO_MYPYC: "1"
       run: |
         python -m pip install --upgrade pip
-        make deps
+        pip install --progress-bar off -e ".[dev]"
     - name: Format
       run: make format-check
     - name: Type annotations

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,11 +16,7 @@ jobs:
         python-version: "3.14"
         cache: pip
         cache-dependency-path: setup.py
-    # TODO: Remove NO_MYPYC once mypyc type issues are resolved
-    # See: https://github.com/barakalon/mysql-mimic/pull/73
     - name: Install dependencies
-      env:
-        NO_MYPYC: "1"
       run: |
         python -m pip install --upgrade pip
         pip install --progress-bar off -e ".[dev]"
@@ -56,11 +52,7 @@ jobs:
     - name: Install make (Windows)
       if: runner.os == 'Windows'
       run: choco install make -y
-    # TODO: Remove NO_MYPYC once mypyc type issues are resolved
-    # See: https://github.com/barakalon/mysql-mimic/pull/73
     - name: Install dependencies
-      env:
-        NO_MYPYC: "1"
       run: |
         python -m pip install --upgrade pip
         make deps
@@ -80,11 +72,7 @@ jobs:
         python-version: "3.14"
         cache: pip
         cache-dependency-path: setup.py
-    # TODO: Remove NO_MYPYC once mypyc type issues are resolved
-    # See: https://github.com/barakalon/mysql-mimic/pull/73
     - name: Install Python dependencies
-      env:
-        NO_MYPYC: "1"
       run: |
         python -m pip install --upgrade pip
         make deps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,65 +7,91 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        version: [
-            { python: "3.7", ubuntu: "ubuntu-22.04" },
-            { python: "3.8", ubuntu: "ubuntu-22.04" },
-            { python: "3.9", ubuntu: "ubuntu-latest" },
-            { python: "3.10", ubuntu: "ubuntu-latest" },
-            { python: "3.11", ubuntu: "ubuntu-latest" },
-            { python: "3.12", ubuntu: "ubuntu-latest" } ]
-    runs-on: ${{ matrix.version.ubuntu }}
+  lint:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Kerberos
-      run: sudo apt-get install -y libkrb5-dev krb5-kdc krb5-admin-server
-    - name: Set up Python ${{ matrix.version.python }}
-      uses: actions/setup-python@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.version.python }}
+        python-version: "3.14"
         cache: pip
         cache-dependency-path: setup.py
+    # TODO: Remove NO_MYPYC once mypyc type issues are resolved
+    # See: https://github.com/barakalon/mysql-mimic/pull/73
     - name: Install dependencies
+      env:
+        NO_MYPYC: "1"
+      run: |
+        python -m pip install --upgrade pip
+        make deps
+    - name: Format
+      run: make format-check
+    - name: Type annotations
+      run: make types
+
+  test:
+    needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        os: [ubuntu-latest, windows-latest]
+        exclude:
+          - { python: "3.7", os: "ubuntu-latest" }
+          - { python: "3.8", os: "ubuntu-latest" }
+        include:
+          - { python: "3.7", os: "ubuntu-22.04" }  # EOL — needs older runner
+          - { python: "3.8", os: "ubuntu-22.04" }  # EOL — needs older runner
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Kerberos
+      if: runner.os == 'Linux'
+      run: sudo apt-get install -y libkrb5-dev krb5-kdc krb5-admin-server
+    - uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python }}
+        cache: pip
+        cache-dependency-path: setup.py
+    - name: Install make (Windows)
+      if: runner.os == 'Windows'
+      run: choco install make -y
+    # TODO: Remove NO_MYPYC once mypyc type issues are resolved
+    # See: https://github.com/barakalon/mysql-mimic/pull/73
+    - name: Install dependencies
+      env:
+        NO_MYPYC: "1"
       run: |
         python -m pip install --upgrade pip
         make deps
     - name: Test
-      run: |
-        make test
-    - name: Format
-      if: matrix.version.python == '3.12'
-      run: |
-        make format-check
-    - name: Type annotations
-      if: matrix.version.python == '3.12'
-      run: |
-        make types
-  mysql-connector-j:
+      run: make test
+
+  integration:
+    needs: lint
     name: Integration (mysql-connector-j)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Set up Kerberos
       run: sudo apt-get install -y libkrb5-dev krb5-kdc krb5-admin-server
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
-        python-version: '3.10'
+        python-version: "3.14"
         cache: pip
         cache-dependency-path: setup.py
+    # TODO: Remove NO_MYPYC once mypyc type issues are resolved
+    # See: https://github.com/barakalon/mysql-mimic/pull/73
     - name: Install Python dependencies
+      env:
+        NO_MYPYC: "1"
       run: |
         python -m pip install --upgrade pip
         make deps
-    - name: Set up Java
-      uses: actions/setup-java@v3
+    - uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '17'
         cache: 'maven'
     - name: Test mysql-connector-j
-      run: |
-        python integration/run.py integration/mysql-connector-j/
+      run: python integration/run.py integration/mysql-connector-j/

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,14 @@
 
 .PHONY: deps format format-check run test build publish clean
 
+# Install dev dependencies; skip Kerberos deps on Windows (requires libkrb5-dev)
+ifeq ($(OS),Windows_NT)
 deps:
-	pip install --progress-bar off -e .[dev]
+	pip install --progress-bar off -e ".[dev]"
+else
+deps:
+	pip install --progress-bar off -e ".[dev,dev-krb5]"
+endif
 
 format:
 	python -m black .

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,15 @@
 
 .PHONY: deps format format-check run test build publish clean
 
-# Install dev dependencies; skip Kerberos deps on Windows (requires libkrb5-dev)
-ifeq ($(OS),Windows_NT)
-deps:
-	pip install --progress-bar off -e ".[dev]"
-else
+# Kerberos dev dependencies (gssapi, k5test) require system krb5 libraries
+# which are only reliably available on Linux. Skip on Windows and macOS.
+UNAME_S := $(shell uname -s 2>/dev/null)
+ifeq ($(UNAME_S),Linux)
 deps:
 	pip install --progress-bar off -e ".[dev,dev-krb5]"
+else
+deps:
+	pip install --progress-bar off -e ".[dev]"
 endif
 
 format:

--- a/mysql_mimic/charset.py
+++ b/mysql_mimic/charset.py
@@ -55,7 +55,7 @@ class CharacterSet(IntEnum):
     def default_collation(self) -> Collation:
         return DEFAULT_COLLATIONS[self]
 
-    def decode(self, b: bytes) -> str:
+    def decode(self, b: bytes | bytearray) -> str:
         return b.decode(self.codec)
 
     def encode(self, s: str) -> bytes:

--- a/mysql_mimic/results.py
+++ b/mysql_mimic/results.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, date, timedelta
 from typing import (
     Iterable,
+    List,
     Sequence,
     Optional,
     Callable,
@@ -408,20 +409,25 @@ class NullBitmap:
 
     __slots__ = ("offset", "bitmap")
 
-    def __init__(self, bitmap: bytearray, offset: int = 0):
+    # bitmap is List[int] rather than bytearray because mypyc does not support
+    # bytearray as a native type. Each element represents one byte (0-255).
+    # This preserves the same indexing and mutation semantics as bytearray.
+    def __init__(self, bitmap: List[int], offset: int = 0):
         self.offset = offset
         self.bitmap = bitmap
 
     @classmethod
     def new(cls, num_bits: int, offset: int = 0) -> NullBitmap:
-        bitmap = bytearray(cls._num_bytes(num_bits, offset))
+        # Zero-filled list of bytes, equivalent to bytearray(n)
+        bitmap = [0] * cls._num_bytes(num_bits, offset)
         return cls(bitmap, offset)
 
     @classmethod
     def from_buffer(
         cls, buffer: io.BytesIO, num_bits: int, offset: int = 0
     ) -> NullBitmap:
-        bitmap = bytearray(buffer.read(cls._num_bytes(num_bits, offset)))
+        # Convert bytes from buffer to list of ints, equivalent to bytearray(...)
+        bitmap = list(buffer.read(cls._num_bytes(num_bits, offset)))
         return cls(bitmap, offset)
 
     @classmethod

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     python_requires=">=3.6",
     install_requires=["sqlglot"],
     extras_require={
+        # Core dev dependencies — cross-platform, works on Linux, macOS, and Windows
         "dev": [
             "aiomysql",
             "mypy",
@@ -48,8 +49,6 @@ setup(
             "black",
             "coverage",
             "freezegun",
-            "gssapi",
-            "k5test",
             "pylint",
             "pytest",
             "pytest-asyncio",
@@ -57,6 +56,12 @@ setup(
             "sqlalchemy",
             "twine",
             "wheel",
+        ],
+        # Kerberos dev dependencies — requires system krb5 libraries (Linux only in CI)
+        # gssapi and k5test need libkrb5-dev which is not available on Windows
+        "dev-krb5": [
+            "gssapi",
+            "k5test",
         ],
         "krb5": ["gssapi"],
     },

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.version_info >= (3, 9) and not os.environ.get("NO_MYPYC"):
         ext_modules = mypycify(
             MYPYC_MODULES, opt_level=os.environ.get("MYPYC_OPT_LEVEL", "3")
         )
-    except Exception:
+    except ImportError:
         pass
 
 setup(


### PR DESCRIPTION
## Summary

Fixes two mypyc compilation errors that were silently swallowed by `except Exception` in setup.py, and removes the `NO_MYPYC` workaround from CI (introduced in #75).

- **charset.py**: Widen `CharacterSet.decode()` type from `bytes` to `bytes | bytearray` — `packets.py:589` passes `bytearray` buffers which fails mypyc's strict type checking
- **results.py**: Replace `bytearray` with `List[int]` in `NullBitmap` — mypyc does not support `bytearray` as a native type (`ValueError: bytearray is not a valid sequence`). `List[int]` preserves the same indexing and mutation semantics.
- **tests.yml**: Remove `NO_MYPYC=1` from all CI jobs now that compilation passes cleanly. The lint job validates mypyc compilation on every PR.

Fixes #72. Supersedes #73.

## Depends on

#75 (CI modernization) — should be merged first.

## Test plan

- [x] `python test_mypyc.py` compiles all 6 extensions successfully
- [x] 439 tests pass locally
- [x] CI fully green (lint with mypyc validation, all test matrix entries, integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)