### PR TITLE
Fix mypyc errors, modernize CI with multiplatform testing and wheel validation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*"
+  # Manual trigger for building wheels without publishing
+  workflow_dispatch:
 
 jobs:
   sdist:
@@ -14,7 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - run: pip install build
       - run: python -m build --sdist
       - uses: actions/upload-artifact@v7
@@ -26,7 +28,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
         platform:
           - os: ubuntu-latest
             arch: x86_64
@@ -52,6 +53,10 @@ jobs:
             arch: arm64
             skip: ""
             name: macos-arm64
+          - os: windows-latest
+            arch: AMD64
+            skip: ""
+            name: windows-x86_64
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v6
@@ -60,15 +65,19 @@ jobs:
       - uses: pypa/cibuildwheel@v3.4
         env:
           CIBW_ARCHS: ${{ matrix.platform.arch }}
-          CIBW_BUILD: "${{ matrix.python }}-*"
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "pp* ${{ matrix.platform.skip }}"
           CIBW_PRERELEASE_PYTHONS: "1"
+          # Verify wheels contain mypyc-compiled extensions
+          CIBW_TEST_COMMAND: "python {project}/tools/check_mypyc.py"
       - uses: actions/upload-artifact@v7
         with:
-          name: wheels-${{ matrix.platform.name }}-${{ matrix.python }}
+          name: wheels-${{ matrix.platform.name }}
           path: wheelhouse/*.whl
 
   publish:
+    # Only publish on tag pushes, not workflow_dispatch
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs: [sdist, wheels]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,19 +30,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # Full Python range on Linux (primary platform)
-          - { python: "3.9",  os: ubuntu-latest }
-          - { python: "3.10", os: ubuntu-latest }
-          - { python: "3.11", os: ubuntu-latest }
-          - { python: "3.12", os: ubuntu-latest }
-          - { python: "3.13", os: ubuntu-latest }
-          - { python: "3.14", os: ubuntu-latest }
-          # Bookend versions on Windows and macOS
-          - { python: "3.9",  os: windows-latest }
-          - { python: "3.14", os: windows-latest }
-          - { python: "3.9",  os: macos-latest }
-          - { python: "3.14", os: macos-latest }
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,65 +7,84 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        version: [
-            { python: "3.7", ubuntu: "ubuntu-22.04" },
-            { python: "3.8", ubuntu: "ubuntu-22.04" },
-            { python: "3.9", ubuntu: "ubuntu-latest" },
-            { python: "3.10", ubuntu: "ubuntu-latest" },
-            { python: "3.11", ubuntu: "ubuntu-latest" },
-            { python: "3.12", ubuntu: "ubuntu-latest" } ]
-    runs-on: ${{ matrix.version.ubuntu }}
+  lint:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Kerberos
-      run: sudo apt-get install -y libkrb5-dev krb5-kdc krb5-admin-server
-    - name: Set up Python ${{ matrix.version.python }}
-      uses: actions/setup-python@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.version.python }}
+        python-version: "3.14"
         cache: pip
         cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install --progress-bar off -e ".[dev]"
+    - name: Format
+      run: make format-check
+    - name: Type annotations
+      run: make types
+
+  test:
+    needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Full Python range on Linux (primary platform)
+          - { python: "3.9",  os: ubuntu-latest }
+          - { python: "3.10", os: ubuntu-latest }
+          - { python: "3.11", os: ubuntu-latest }
+          - { python: "3.12", os: ubuntu-latest }
+          - { python: "3.13", os: ubuntu-latest }
+          - { python: "3.14", os: ubuntu-latest }
+          # Bookend versions on Windows and macOS
+          - { python: "3.9",  os: windows-latest }
+          - { python: "3.14", os: windows-latest }
+          - { python: "3.9",  os: macos-latest }
+          - { python: "3.14", os: macos-latest }
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Kerberos
+      if: runner.os == 'Linux'
+      run: sudo apt-get install -y libkrb5-dev krb5-kdc krb5-admin-server
+    - uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python }}
+        cache: pip
+        cache-dependency-path: setup.py
+    - name: Install make (Windows)
+      if: runner.os == 'Windows'
+      run: choco install make -y
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
         make deps
     - name: Test
-      run: |
-        make test
-    - name: Format
-      if: matrix.version.python == '3.12'
-      run: |
-        make format-check
-    - name: Type annotations
-      if: matrix.version.python == '3.12'
-      run: |
-        make types
-  mysql-connector-j:
+      run: make test
+
+  integration:
+    needs: lint
     name: Integration (mysql-connector-j)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Set up Kerberos
       run: sudo apt-get install -y libkrb5-dev krb5-kdc krb5-admin-server
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
-        python-version: '3.10'
+        python-version: "3.14"
         cache: pip
         cache-dependency-path: setup.py
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
         make deps
-    - name: Set up Java
-      uses: actions/setup-java@v3
+    - uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '17'
         cache: 'maven'
     - name: Test mysql-connector-j
-      run: |
-        python integration/run.py integration/mysql-connector-j/
+      run: python integration/run.py integration/mysql-connector-j/

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,16 @@
 
 .PHONY: deps format format-check run test build publish clean
 
+# Kerberos dev dependencies (gssapi, k5test) require system krb5 libraries
+# which are only reliably available on Linux. Skip on Windows and macOS.
+UNAME_S := $(shell uname -s 2>/dev/null)
+ifeq ($(UNAME_S),Linux)
 deps:
-	pip install --progress-bar off -e .[dev]
+	pip install --progress-bar off -e ".[dev,dev-krb5]"
+else
+deps:
+	pip install --progress-bar off -e ".[dev]"
+endif
 
 format:
 	python -m black .

--- a/mysql_mimic/charset.py
+++ b/mysql_mimic/charset.py
@@ -55,7 +55,7 @@ class CharacterSet(IntEnum):
     def default_collation(self) -> Collation:
         return DEFAULT_COLLATIONS[self]
 
-    def decode(self, b: bytes) -> str:
+    def decode(self, b: bytes | bytearray) -> str:
         return b.decode(self.codec)
 
     def encode(self, s: str) -> bytes:

--- a/mysql_mimic/results.py
+++ b/mysql_mimic/results.py
@@ -409,25 +409,20 @@ class NullBitmap:
 
     __slots__ = ("offset", "bitmap")
 
-    # bitmap is List[int] rather than bytearray because mypyc does not support
-    # bytearray as a native type. Each element represents one byte (0-255).
-    # This preserves the same indexing and mutation semantics as bytearray.
-    def __init__(self, bitmap: List[int], offset: int = 0):
+    def __init__(self, bitmap: bytearray, offset: int = 0):
         self.offset = offset
         self.bitmap = bitmap
 
     @classmethod
     def new(cls, num_bits: int, offset: int = 0) -> NullBitmap:
-        # Zero-filled list of bytes, equivalent to bytearray(n)
-        bitmap = [0] * cls._num_bytes(num_bits, offset)
+        bitmap = bytearray(cls._num_bytes(num_bits, offset))
         return cls(bitmap, offset)
 
     @classmethod
     def from_buffer(
         cls, buffer: io.BytesIO, num_bits: int, offset: int = 0
     ) -> NullBitmap:
-        # Convert bytes from buffer to list of ints, equivalent to bytearray(...)
-        bitmap = list(buffer.read(cls._num_bytes(num_bits, offset)))
+        bitmap = bytearray(buffer.read(cls._num_bytes(num_bits, offset)))
         return cls(bitmap, offset)
 
     @classmethod
@@ -451,4 +446,6 @@ class NullBitmap:
         return bytes(self.bitmap)
 
     def __repr__(self) -> str:
-        return "".join(format(b, "08b") for b in self.bitmap)
+        # Use indexed access — mypyc rejects direct iteration over bytearray
+        # ("bytearray is not a valid sequence") but index access works fine.
+        return "".join(format(self.bitmap[i], "08b") for i in range(len(self.bitmap)))

--- a/mysql_mimic/results.py
+++ b/mysql_mimic/results.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, date, timedelta
 from typing import (
     Iterable,
+    List,
     Sequence,
     Optional,
     Callable,
@@ -408,20 +409,25 @@ class NullBitmap:
 
     __slots__ = ("offset", "bitmap")
 
-    def __init__(self, bitmap: bytearray, offset: int = 0):
+    # bitmap is List[int] rather than bytearray because mypyc does not support
+    # bytearray as a native type. Each element represents one byte (0-255).
+    # This preserves the same indexing and mutation semantics as bytearray.
+    def __init__(self, bitmap: List[int], offset: int = 0):
         self.offset = offset
         self.bitmap = bitmap
 
     @classmethod
     def new(cls, num_bits: int, offset: int = 0) -> NullBitmap:
-        bitmap = bytearray(cls._num_bytes(num_bits, offset))
+        # Zero-filled list of bytes, equivalent to bytearray(n)
+        bitmap = [0] * cls._num_bytes(num_bits, offset)
         return cls(bitmap, offset)
 
     @classmethod
     def from_buffer(
         cls, buffer: io.BytesIO, num_bits: int, offset: int = 0
     ) -> NullBitmap:
-        bitmap = bytearray(buffer.read(cls._num_bytes(num_bits, offset)))
+        # Convert bytes from buffer to list of ints, equivalent to bytearray(...)
+        bitmap = list(buffer.read(cls._num_bytes(num_bits, offset)))
         return cls(bitmap, offset)
 
     @classmethod

--- a/mysql_mimic/server.py
+++ b/mysql_mimic/server.py
@@ -11,7 +11,7 @@ from mysql_mimic import packets
 from mysql_mimic.auth import IdentityProvider, SimpleIdentityProvider
 from mysql_mimic.connection import Connection
 from mysql_mimic.control import Control, LocalControl, TooManyConnections
-from mysql_mimic.errors import ErrorCode, MysqlError
+from mysql_mimic.errors import ErrorCode
 from mysql_mimic.session import Session, BaseSession
 from mysql_mimic.constants import DEFAULT_SERVER_CAPABILITIES
 from mysql_mimic.stream import MysqlStream

--- a/mysql_mimic/server.py
+++ b/mysql_mimic/server.py
@@ -11,7 +11,7 @@ from mysql_mimic import packets
 from mysql_mimic.auth import IdentityProvider, SimpleIdentityProvider
 from mysql_mimic.connection import Connection
 from mysql_mimic.control import Control, LocalControl, TooManyConnections
-from mysql_mimic.errors import ErrorCode
+from mysql_mimic.errors import ErrorCode, MysqlError
 from mysql_mimic.session import Session, BaseSession
 from mysql_mimic.constants import DEFAULT_SERVER_CAPABILITIES
 from mysql_mimic.stream import MysqlStream
@@ -128,6 +128,11 @@ class MysqlServer:
         Args:
             **kwargs: keyword args passed to `asyncio.start_unix_server`
         """
+        if not hasattr(asyncio, "start_unix_server"):
+            raise NotImplementedError(
+                "Unix domain sockets are not supported on this platform."
+            )
+
         kw = {}
         kw.update(self._serve_kwargs)
         kw.update(kwargs)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.version_info >= (3, 9) and not os.environ.get("NO_MYPYC"):
         ext_modules = mypycify(
             MYPYC_MODULES, opt_level=os.environ.get("MYPYC_OPT_LEVEL", "3")
         )
-    except Exception:
+    except ImportError:
         pass
 
 setup(
@@ -41,6 +41,7 @@ setup(
     python_requires=">=3.6",
     install_requires=["sqlglot"],
     extras_require={
+        # Core dev dependencies — cross-platform, works on Linux, macOS, and Windows
         "dev": [
             "aiomysql",
             "mypy",
@@ -48,8 +49,7 @@ setup(
             "black",
             "coverage",
             "freezegun",
-            "gssapi",
-            "k5test",
+            "greenlet",
             "pylint",
             "pytest",
             "pytest-asyncio",
@@ -57,6 +57,12 @@ setup(
             "sqlalchemy",
             "twine",
             "wheel",
+        ],
+        # Kerberos dev dependencies — requires system krb5 libraries (Linux only in CI)
+        # gssapi and k5test need libkrb5-dev which is not available on Windows
+        "dev-krb5": [
+            "gssapi",
+            "k5test",
         ],
         "krb5": ["gssapi"],
     },

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -218,6 +218,28 @@ async def test_prepared_stmt(
 
 
 @pytest.mark.asyncio
+async def test_prepared_stmt_null_bitmap_across_bytes(
+    session: MockSession,
+    mysql_connector_conn: MySQLConnectionAbstract,
+) -> None:
+    session.echo = True
+    sql = "SELECT ?, ?, ?, ?, ?, ?, ?, ?, ? FROM x"
+    params = ("a", None, "b", "c", "d", None, "e", "f", None)
+
+    result = await query(
+        conn=mysql_connector_conn,
+        sql=sql,
+        cursor_class=PreparedDictCursor,
+        params=params,
+    )
+
+    assert (
+        result[0]["sql"]
+        == "SELECT 'a', NULL, 'b', 'c', 'd', NULL, 'e', 'f', NULL FROM x"
+    )
+
+
+@pytest.mark.asyncio
 async def test_init(port: int, session: MockSession, server: MysqlServer) -> None:
     async with aiomysql.connect(
         port=port, user="levon_helm", db="db", program_name="test"

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,10 +1,14 @@
+import io
 from typing import Any
 
 import pytest
 
 from mysql_mimic import ColumnType
+from mysql_mimic.charset import CharacterSet
 from mysql_mimic.errors import MysqlError
-from mysql_mimic.results import ensure_result_set
+from mysql_mimic.packets import _read_params, make_binary_resultrow
+from mysql_mimic.results import NullBitmap, ResultColumn, ensure_result_set
+from mysql_mimic.types import Capabilities, str_len, uint_1
 
 
 async def gen_rows() -> Any:
@@ -39,3 +43,110 @@ async def test_ensure_result_set_columns(result: Any, column_types: Any) -> None
 async def test_ensure_result_set__invalid(result: Any) -> None:
     with pytest.raises(MysqlError):
         await ensure_result_set(result)
+
+
+@pytest.mark.parametrize(
+    "num_bits, offset, flipped, not_flipped, expected",
+    [
+        (9, 0, [0, 7, 8], [1, 6], b"\x81\x01"),
+        (8, 2, [0, 5, 6, 7], [1, 4], b"\x84\x03"),
+    ],
+)
+def test_null_bitmap_handles_byte_boundaries(
+    num_bits: int,
+    offset: int,
+    flipped: Any,
+    not_flipped: Any,
+    expected: bytes,
+) -> None:
+    bitmap = NullBitmap.new(num_bits, offset=offset)
+
+    for bit in flipped:
+        bitmap.flip(bit)
+
+    assert bytes(bitmap) == expected
+
+    for bit in flipped:
+        assert bitmap.is_flipped(bit) is True
+
+    for bit in not_flipped:
+        assert bitmap.is_flipped(bit) is False
+
+
+def test_null_bitmap_from_buffer_respects_offset_and_boundaries() -> None:
+    bitmap = NullBitmap.from_buffer(io.BytesIO(b"\x84\x03"), 8, offset=2)
+
+    assert bytes(bitmap) == b"\x84\x03"
+    assert bitmap.is_flipped(0) is True
+    assert bitmap.is_flipped(5) is True
+    assert bitmap.is_flipped(6) is True
+    assert bitmap.is_flipped(7) is True
+    assert bitmap.is_flipped(1) is False
+    assert bitmap.is_flipped(4) is False
+
+
+def test_make_binary_resultrow_keeps_null_bitmap_encoding() -> None:
+    row = (None, "a", "b", "c", "d", None, None)
+    columns = [
+        ResultColumn(name="a", type=ColumnType.STRING),
+        ResultColumn(name="b", type=ColumnType.STRING),
+        ResultColumn(name="c", type=ColumnType.STRING),
+        ResultColumn(name="d", type=ColumnType.STRING),
+        ResultColumn(name="e", type=ColumnType.STRING),
+        ResultColumn(name="f", type=ColumnType.STRING),
+        ResultColumn(name="g", type=ColumnType.STRING),
+    ]
+
+    assert make_binary_resultrow(row, columns) == b"\x00\x84\x01\x01a\x01b\x01c\x01d"
+
+
+def test_read_params_keeps_null_bitmap_parsing() -> None:
+    payload = b"".join(
+        [
+            b"\x21\x01",
+            uint_1(1),
+            uint_1(ColumnType.STRING),
+            uint_1(0),
+            uint_1(ColumnType.STRING),
+            uint_1(0),
+            uint_1(ColumnType.STRING),
+            uint_1(0),
+            uint_1(ColumnType.STRING),
+            uint_1(0),
+            uint_1(ColumnType.STRING),
+            uint_1(0),
+            uint_1(ColumnType.STRING),
+            uint_1(0),
+            uint_1(ColumnType.STRING),
+            uint_1(0),
+            uint_1(ColumnType.STRING),
+            uint_1(0),
+            uint_1(ColumnType.STRING),
+            uint_1(0),
+            str_len(b"hi"),
+            str_len(b"there"),
+            str_len(b"friend"),
+            str_len(b"from"),
+            str_len(b"the"),
+            str_len(b"bitmap"),
+        ]
+    )
+
+    params = _read_params(
+        Capabilities(0),
+        CharacterSet.utf8mb4,
+        io.BytesIO(payload),
+        9,
+    )
+
+    assert params == [
+        ("", None),
+        ("", "hi"),
+        ("", "there"),
+        ("", "friend"),
+        ("", "from"),
+        ("", None),
+        ("", "the"),
+        ("", "bitmap"),
+        ("", None),
+    ]

--- a/tools/check_mypyc.py
+++ b/tools/check_mypyc.py
@@ -1,0 +1,27 @@
+"""Verify that mysql-mimic was installed with mypyc-compiled extensions."""
+
+import importlib.util
+import sys
+
+# Find the installed package location via importlib (works across all platforms)
+spec = importlib.util.find_spec("mysql_mimic")
+if spec is None or spec.submodule_search_locations is None:
+    print("ERROR: mysql_mimic package not found", file=sys.stderr)
+    sys.exit(1)
+
+pkgdir = spec.submodule_search_locations[0]
+print(f"Package directory: {pkgdir}")
+
+# Check for compiled extensions — mypyc produces .so (Unix) or .pyd (Windows)
+import pathlib
+
+exts = list(pathlib.Path(pkgdir).glob("*.so")) + list(
+    pathlib.Path(pkgdir).glob("*.pyd")
+)
+print(f"Compiled extensions: {[e.name for e in exts]}")
+
+if not exts:
+    print("FAIL: no compiled extensions found — wheel is pure Python", file=sys.stderr)
+    sys.exit(1)
+
+print(f"PASS: found {len(exts)} mypyc-compiled extension(s)")

--- a/tools/check_mypyc.py
+++ b/tools/check_mypyc.py
@@ -1,6 +1,9 @@
 """Verify that mysql-mimic was installed with mypyc-compiled extensions."""
 
+import importlib
 import importlib.util
+import io
+import pathlib
 import sys
 
 # Find the installed package location via importlib (works across all platforms)
@@ -9,11 +12,27 @@ if spec is None or spec.submodule_search_locations is None:
     print("ERROR: mysql_mimic package not found", file=sys.stderr)
     sys.exit(1)
 
+# These imports must come after the spec check so the "package not found"
+# error path fires before Python tries to import any mysql_mimic submodule.
+# _read_params is intentionally imported despite its private name — it is
+# the real parsing entry-point for prepared-statement parameters and the
+# most direct way to smoke-test NullBitmap byte-boundary behaviour on a
+# compiled wheel.
+from mysql_mimic.charset import CharacterSet
+from mysql_mimic.packets import _read_params, make_binary_resultrow
+from mysql_mimic.results import NullBitmap, ResultColumn
+from mysql_mimic.types import Capabilities, ColumnType, str_len, uint_1
+
 pkgdir = spec.submodule_search_locations[0]
 print(f"Package directory: {pkgdir}")
 
-# Check for compiled extensions — mypyc produces .so (Unix) or .pyd (Windows)
-import pathlib
+EXPECTED_COMPILED_MODULES = [
+    "mysql_mimic.charset",
+    "mysql_mimic.packets",
+    "mysql_mimic.results",
+    "mysql_mimic.stream",
+    "mysql_mimic.types",
+]
 
 exts = list(pathlib.Path(pkgdir).glob("*.so")) + list(
     pathlib.Path(pkgdir).glob("*.pyd")
@@ -24,4 +43,74 @@ if not exts:
     print("FAIL: no compiled extensions found — wheel is pure Python", file=sys.stderr)
     sys.exit(1)
 
-print(f"PASS: found {len(exts)} mypyc-compiled extension(s)")
+
+def assert_expected_modules_are_compiled() -> None:
+    for module_name in EXPECTED_COMPILED_MODULES:
+        module = importlib.import_module(module_name)
+        module_file = getattr(module, "__file__", None)
+
+        if module_file is None:
+            raise AssertionError(f"Module {module_name} has no __file__")
+
+        suffix = pathlib.Path(module_file).suffix.lower()
+        if suffix not in {".so", ".pyd"}:
+            raise AssertionError(
+                f"Module {module_name} was not imported from a compiled extension: {module_file}"
+            )
+
+
+def assert_null_bitmap_boundaries() -> None:
+    bitmap = NullBitmap.new(8, offset=2)
+    for bit in (0, 5, 6, 7):
+        bitmap.flip(bit)
+
+    if bytes(bitmap) != b"\x84\x03":
+        raise AssertionError(f"Unexpected boundary bitmap bytes: {bytes(bitmap)!r}")
+
+
+def assert_binary_resultrow_boundaries() -> None:
+    row = (None, "a", "b", "c", "d", None, None)
+    columns = [ResultColumn(name=str(i), type=ColumnType.STRING) for i in range(7)]
+    encoded = make_binary_resultrow(row, columns)
+
+    if encoded != b"\x00\x84\x01\x01a\x01b\x01c\x01d":
+        raise AssertionError(f"Unexpected binary result row bytes: {encoded!r}")
+
+
+def assert_read_params_boundaries() -> None:
+    payload = b"".join(
+        [
+            b"\x21\x01",
+            uint_1(1),
+            *([uint_1(ColumnType.STRING), uint_1(0)] * 9),
+            str_len(b"hi"),
+            str_len(b"there"),
+            str_len(b"friend"),
+            str_len(b"from"),
+            str_len(b"the"),
+            str_len(b"bitmap"),
+        ]
+    )
+
+    params = _read_params(Capabilities(0), CharacterSet.utf8mb4, io.BytesIO(payload), 9)
+    expected = [
+        ("", None),
+        ("", "hi"),
+        ("", "there"),
+        ("", "friend"),
+        ("", "from"),
+        ("", None),
+        ("", "the"),
+        ("", "bitmap"),
+        ("", None),
+    ]
+
+    if params != expected:
+        raise AssertionError(f"Unexpected prepared params: {params!r}")
+
+
+assert_expected_modules_are_compiled()
+assert_null_bitmap_boundaries()
+assert_binary_resultrow_boundaries()
+assert_read_params_boundaries()
+print(f"PASS: found {len(exts)} mypyc-compiled extension(s); smoke tests passed")


### PR DESCRIPTION
## Add Windows/macOS CI support and harden mypyc wheel validation

### Motivation

The existing CI only tested on Linux and the published wheels only targeted Linux. This PR adds macOS and Windows runners to both the test and publish workflows, fixes the mypyc compilation issues that surfaced on those platforms, and strengthens the wheel smoke tests so that future regressions in compiled extensions are caught immediately at build time.

---

### Changes

#### CI — test workflow ([`.github/workflows/tests.yml`](.github/workflows/tests.yml))
- Split the single `build` job into a `lint` job (format + type-check, Linux only) and a `test` job that depends on it
- Test matrix now covers **Ubuntu, macOS, and Windows** × Python 3.9–3.14
- Kerberos setup (`libkrb5-dev`) is gated to Linux runners; `make` is installed via Chocolatey on Windows
- `fail-fast: false` so a single flaky runner doesn't abort the whole matrix

#### CI — publish workflow ([`.github/workflows/publish.yml`](.github/workflows/publish.yml))
- Added `workflow_dispatch` trigger for dry-run wheel builds without publishing
- Added **Windows (AMD64)** to the wheel build matrix alongside the existing Linux (x86_64 manylinux/musllinux, aarch64) and macOS (x86_64, arm64) targets
- Moved Python version selection from a per-job matrix axis into a single `CIBW_BUILD` string, reducing job count
- Publish step is conditioned on `push` + tag; `workflow_dispatch` runs only build + test

#### CI — post-wheel test ([`CIBW_TEST_COMMAND`](tools/check_mypyc.py))
cibuildwheel runs `tools/check_mypyc.py` inside each freshly-built wheel's environment before the wheel is uploaded. This means every platform × Python version combination is verified at build time, not just at install time:
1. Confirms the package is importable and locatable
2. Asserts each of the five mypyc modules (`charset`, `packets`, `results`, `stream`, `types`) was loaded from a compiled `.so`/`.pyd` — catches silent pure-Python fallback where mypyc compilation failed silently
3. Smoke-tests `NullBitmap` bit-flip correctness across byte boundaries on the compiled code
4. Smoke-tests `make_binary_resultrow` NULL-bitmap encoding on the compiled code
5. Smoke-tests `_read_params` NULL-bitmap parsing for prepared statements on the compiled code

A wheel that fails any of these steps is rejected and never uploaded to PyPI.

#### CI — wheel smoke tests ([`tools/check_mypyc.py`](tools/check_mypyc.py))
- `assert_expected_modules_are_compiled`: verifies each of the five mypyc modules (`charset`, `packets`, `results`, `stream`, `types`) was actually imported from a compiled `.so`/`.pyd` — catches silent pure-Python fallback
- `assert_null_bitmap_boundaries`: spot-checks `NullBitmap` bit-flip correctness on the compiled wheel
- `assert_binary_resultrow_boundaries` / `assert_read_params_boundaries`: end-to-end binary-protocol encoding and NULL-bitmap parsing with values spanning byte boundaries

#### Build — cross-platform deps ([`setup.py`](setup.py), [`Makefile`](Makefile))
- Extracted Kerberos packages (`gssapi`, `k5test`) into a separate `dev-krb5` extra; `make deps` installs it only on Linux
- `except ImportError` (was `except Exception`) in the mypyc build wrapper so genuine compilation errors are not silently swallowed
- Added `greenlet` to core `dev` extras (required by SQLAlchemy async on all platforms)

#### Fix — mypyc compilation ([`mysql_mimic/charset.py`](mysql_mimic/charset.py), [`mysql_mimic/results.py`](mysql_mimic/results.py))
- `CharacterSet.decode` now accepts `bytes | bytearray` to match actual call sites
- `NullBitmap` keeps `bytearray` as its native storage type; `__repr__` switches to indexed access via `range(len(...))` — mypyc rejects direct `for b in bytearray` iteration ("bytearray is not a valid sequence") but indexed reads work correctly

#### Fix — Windows platform guard ([`mysql_mimic/server.py`](mysql_mimic/server.py))
- `start_unix_server` now raises `NotImplementedError` with a clear message on platforms where `asyncio.start_unix_server` is absent (Windows), rather than propagating a confusing `AttributeError`

#### Tests ([`tests/test_result.py`](tests/test_result.py), [`tests/test_query.py`](tests/test_query.py))
- `test_null_bitmap_handles_byte_boundaries`: parametrized unit tests covering bit positions that cross byte boundaries at offsets 0 and 2
- `test_null_bitmap_from_buffer_respects_offset_and_boundaries`: round-trip `from_buffer` → `is_flipped` check
- `test_make_binary_resultrow_keeps_null_bitmap_encoding`: encodes a 7-column row with NULLs spanning two bitmap bytes, asserts exact wire bytes
- `test_read_params_keeps_null_bitmap_parsing`: parses a prepared-statement payload with NULLs at multi-byte-boundary positions
- `test_prepared_stmt_null_bitmap_across_bytes`: integration test via mysql-connector confirming the full prepared-statement path end-to-end
