### PR TITLE
Fix BufferError in stream drain on Python 3.13 / uvloop

### DIFF
--- a/mysql_mimic/stream.py
+++ b/mysql_mimic/stream.py
@@ -149,7 +149,7 @@ class MysqlStream:
     async def drain(self) -> None:
         if self._buffer:
             self.writer.write(self._buffer)
-            self._buffer.clear()
+            self._buffer = bytearray()
         await self.writer.drain()
 
     def reset_seq(self) -> None:

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
             "sphinx",
             "sqlalchemy",
             "twine",
+            "uvloop; sys_platform != 'win32'",
             "wheel",
         ],
         # Kerberos dev dependencies — requires system krb5 libraries (Linux only in CI)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,3 +1,6 @@
+import asyncio
+import socket
+
 import pytest
 
 from mysql_mimic.errors import MysqlError
@@ -145,3 +148,30 @@ async def test_large_write() -> None:
         writer.data == b"\xff\xff\xff\x00" + bytes(0xFFFFFF) + b"\x06\x00\x00\x01kelsin"
     )
     assert next(s.seq) == 2
+
+
+def test_drain_does_not_raise_buffer_error_on_uvloop() -> None:
+    uvloop = pytest.importorskip("uvloop")
+
+    async def run() -> None:
+        sock1, sock2 = socket.socketpair()
+        try:
+            reader, writer = await asyncio.open_connection(sock=sock1)
+            _, peer_writer = await asyncio.open_connection(sock=sock2)
+            try:
+                stream = MysqlStream(reader=reader, writer=writer)
+                payload = b"x" * 4096
+                for _ in range(4):
+                    await stream.write(payload, drain=True)
+            finally:
+                writer.close()
+                peer_writer.close()
+        finally:
+            sock1.close()
+            sock2.close()
+
+    loop = uvloop.new_event_loop()
+    try:
+        loop.run_until_complete(run())
+    finally:
+        loop.close()


### PR DESCRIPTION
## Summary
The asyncio writer holds a buffer view onto `self._buffer`, so calling `.clear()` raises `BufferError: Existing exports of data: object cannot be re-sized` on Python 3.13's default asyncio (and uvloop). Replacing the bytearray with a fresh one avoids resizing the exported buffer.

## Test plan
- [x] `bench.py` runs cleanly on Python 3.13 (text path: ~25 ms / ~400k rows/s for 10k rows)
- [x] Micro-benchmark of the drain-reset pattern shows no perf regression (slight improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)